### PR TITLE
Fixed sorting for DISTINCT queries: Using compare-function for insert…

### DIFF
--- a/src/rasqal_engine_sort.c
+++ b/src/rasqal_engine_sort.c
@@ -91,6 +91,15 @@ rasqal_engine_rowsort_row_compare(void* user_data, const void *a, const void *b)
     if(!result)
       /* duplicate, so return that */
       return 0;
+
+
+	if (!rcd->order_conditions_sequence) {
+		result = rasqal_literal_array_compare(row_a->values,
+		row_b->values,
+		NULL,
+		row_a->size,
+		rcd->compare_flags);
+	}
   }
   
   /* now order it */

--- a/src/rasqal_literal.c
+++ b/src/rasqal_literal.c
@@ -4403,13 +4403,13 @@ rasqal_literal_array_compare(rasqal_literal** values_a,
 #if defined(RASQAL_DEBUG) && RASQAL_DEBUG > 1
         RASQAL_DEBUG2("Got one NULL literal comparison, returning %d\n", result);
 #endif
-      }
-      break;
-    }
-    
-    result = rasqal_literal_compare(literal_a, literal_b,
-                                    compare_flags | RASQAL_COMPARE_URI,
-                                    &error);
+		break;
+	  }
+	} else {
+		result = rasqal_literal_compare(literal_a, literal_b,
+			compare_flags | RASQAL_COMPARE_URI,
+			&error);
+	}
     if(error) {
 #if defined(RASQAL_DEBUG) && RASQAL_DEBUG > 1
       RASQAL_DEBUG2("Got literal comparison error at expression %d, returning 0\n", i);


### PR DESCRIPTION
…ion in tree-based map for determining uniqueness for DISTINCT queries in order to avoid a totally unbalanced tree (+ fixed literal compare-function for null-bound/unbound variables)