### PR TITLE
Fixed resetting and filling of variable bindings in order to correctly handle UNIONs and aggregations (for SELECT sub-queries)

### DIFF
--- a/src/rasqal_internal.h
+++ b/src/rasqal_internal.h
@@ -1424,6 +1424,10 @@ void rasqal_row_set_rowsource(rasqal_row* row, rasqal_rowsource* rowsource);
 void rasqal_row_set_weak_rowsource(rasqal_row* row, rasqal_rowsource* rowsource);
 rasqal_variable* rasqal_row_get_variable_by_offset(rasqal_row* row, int offset);
 
+raptor_sequence* rasqal_variables_table_take_bindings(rasqal_variables_table* vt);
+void rasqal_variables_table_install_bindings(rasqal_variables_table* vt, raptor_sequence* bindings_sequence);
+
+
 /* rasqal_row_compatible.c */
 rasqal_row_compatible* rasqal_new_row_compatible(rasqal_variables_table* vt, rasqal_rowsource *first_rowsource, rasqal_rowsource *second_rowsource);
 void rasqal_free_row_compatible(rasqal_row_compatible* map);

--- a/src/rasqal_rowsource.c
+++ b/src/rasqal_rowsource.c
@@ -251,9 +251,34 @@ rasqal_rowsource_read_row(rasqal_rowsource *rowsource)
     return NULL;
 
   if(rowsource->flags & RASQAL_ROWSOURCE_FLAGS_SAVED_ROWS) {
+	int i;
+
+
     /* return row from saved rows sequence at offset */
     row = (rasqal_row*)raptor_sequence_get_at(rowsource->rows_sequence,
                                               rowsource->offset++);
+
+
+	// set variable bindings such that, for examples, aggregates can correctly be evaluated
+	for (i = 0; i < rowsource->size; i++) {
+		rasqal_literal *value;
+		rasqal_variable* v;
+		v = rasqal_rowsource_get_variable_by_offset(rowsource, i);
+		if (v) {
+			if (row) {
+				value = row->values[i];
+			} else {
+				value = NULL;
+			}
+			if (value != v->value) {
+				if (value) {
+					value = rasqal_new_literal_from_literal(value);
+				}
+				rasqal_variable_set_value(v, value);
+			}
+		}
+	}
+
 #ifdef RASQAL_DEBUG
     RASQAL_DEBUG3("%s rowsource %p returned saved row:  ",
                   rowsource->handler->name, rowsource);

--- a/src/rasqal_rowsource_assignment.c
+++ b/src/rasqal_rowsource_assignment.c
@@ -140,6 +140,9 @@ rasqal_assignment_rowsource_reset(rasqal_rowsource* rowsource, void *user_data)
   rasqal_assignment_rowsource_context *con;
   con = (rasqal_assignment_rowsource_context*)user_data;
 
+
+  rasqal_variable_set_value(con->var, NULL);
+
   con->offset = 0;
   
   return 0;

--- a/src/rasqal_rowsource_groupby.c
+++ b/src/rasqal_rowsource_groupby.c
@@ -245,6 +245,7 @@ static int
 rasqal_groupby_rowsource_process(rasqal_rowsource* rowsource,
                                  rasqal_groupby_rowsource_context* con)
 {
+  raptor_sequence* bindings;
   /* already processed */
   if(con->processed)
     return 0;
@@ -268,6 +269,8 @@ rasqal_groupby_rowsource_process(rasqal_rowsource* rowsource,
   raptor_avltree_set_print_handler(con->tree,
                                    rasqal_rowsource_groupby_tree_print_node);
   
+
+  bindings = rasqal_variables_table_take_bindings(rowsource->query->vars_table);
 
   while(1) {
     rasqal_row* row;
@@ -330,6 +333,8 @@ rasqal_groupby_rowsource_process(rasqal_rowsource* rowsource,
 
     }
   }
+
+  rasqal_variables_table_install_bindings(rowsource->query->vars_table, bindings);
 
 #ifdef RASQAL_DEBUG
   fputs("Grouping ", DEBUG_FH);

--- a/src/rasqal_rowsource_union.c
+++ b/src/rasqal_rowsource_union.c
@@ -205,9 +205,11 @@ rasqal_union_rowsource_read_row(rasqal_rowsource* rowsource, void *user_data)
     fputs("\n", stderr);
 #endif
 
-    if(!row)
-      con->state = 1;
-    else {
+	if (!row) {
+		con->state = 1;
+		// reset left such that variable bindings (from triple sources, assignments, etc.) are reseted
+		rasqal_rowsource_reset(con->left);
+	} else {
       /* otherwise: rows from left are correct order but wrong size */
       if(rasqal_row_expand_size(row, rowsource->size)) {
         rasqal_free_row(row);
@@ -269,6 +271,8 @@ rasqal_union_rowsource_read_all_rows(rasqal_rowsource* rowsource,
     con->failed = 1;
     return NULL;
   }
+
+  rasqal_rowsource_reset(con->left);
 
   seq2 = rasqal_rowsource_read_all_rows(con->right);
   if(!seq2) {


### PR DESCRIPTION
Required to correctly handle queries as follows:

PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX ub: <http://www.lehigh.edu/~zhp2/2004/0401/univ-bench.owl#>
SELECT ?X ?courseCount
WHERE
{
	{
		?X ub:advisor 	?Y .
						?Y rdf:type ub:Faculty .
						?Y ub:teacherOf ?Z .
										?Z rdf:type ub:Course .
		?X 		ub:takesCourse 			?Z .
	} OPTIONAL {
		SELECT ?X (COUNT(?c) as ?courseCount) {
			?X 		ub:takesCourse 		?c .
		} GROUP BY ?X
	}
} 